### PR TITLE
fix issue with commented escape characters

### DIFF
--- a/jsonc_test.go
+++ b/jsonc_test.go
@@ -23,12 +23,12 @@ var jsonTest, jsoncTest testsStruct
 func init() {
 	jsonTest = testsStruct{
 		validBlock:   b(`{"foo":"bar foo","true":false,"number":42,"object":{"test":"done"},"array":[1,2,3],"url":"https://github.com","escape":"\"wo//rking"}`),
-		invalidBlock: b(`{"foo":\"`),
+		invalidBlock: b(`{"foo":`),
 	}
 	jsoncTest = testsStruct{
-		validBlock:    b(`{"foo": /** this is a bloc/k comment */ "bar foo", "true": /* true */ false, "number": 42, "object": { "test": "done" }, "array" : [1, 2, 3], "url" : "https://github.com", "escape":"\"wo//rking" }`),
+		validBlock:    b(`{"foo": /** this is a bloc/k comm\"ent */ "bar foo", "true": /* true */ false, "number": 42, "object": { "test": "done" }, "array" : [1, 2, 3], "url" : "https://github.com", "escape":"\"wo//rking" }`),
 		invalidBlock:  b(`{"foo": /* this is a block comment "bar foo", "true": false, "number": 42, "object": { "test": "done" }, "array" : [1, 2, 3], "url" : "https://github.com", "escape":"\"wo//rking }`),
-		validSingle:   b("{\"foo\": // this is a single line comment\n\"bar foo\", \"true\": false, \"number\": 42, \"object\": { \"test\": \"done\" }, \"array\" : [1, 2, 3], \"url\" : \"https://github.com\", \"escape\":\"\\\"wo//rking\" }"),
+		validSingle:   b("{\"foo\": // this is a single line comm\\\"ent\n\"bar foo\", \"true\": false, \"number\": 42, \"object\": { \"test\": \"done\" }, \"array\" : [1, 2, 3], \"url\" : \"https://github.com\", \"escape\":\"\\\"wo//rking\" }"),
 		invalidSingle: b(`{"foo": // this is a single line comment "bar foo", "true": false, "number": 42, "object": { "test": "done" }, "array" : [1, 2, 3], "url" : "https://github.com", "escape":"\"wo//rking" }`),
 	}
 }

--- a/translator.go
+++ b/translator.go
@@ -42,8 +42,10 @@ func translate(s []byte) []byte {
 	comment := &commentData{}
 	for _, ch := range s {
 		if ch == ESCAPE || escaped {
-			j[i] = ch
-			i++
+			if !comment.startted {
+				j[i] = ch
+				i++
+			}
 			escaped = !escaped
 			continue
 		}


### PR DESCRIPTION
Do not emit escaped characters if we are currently inside a comment.

closes #10 