### PR TITLE
Fix issue when single line comment is ended by block comment suffix

### DIFF
--- a/translator.go
+++ b/translator.go
@@ -67,7 +67,7 @@ func translate(s []byte) []byte {
 			i++
 			continue
 		}
-		if comment.startted {
+		if comment.startted && !comment.isSingleLined {
 			if ch == ASTERISK {
 				comment.canEnd = true
 				continue

--- a/translator.go
+++ b/translator.go
@@ -67,12 +67,12 @@ func translate(s []byte) []byte {
 			i++
 			continue
 		}
-		if comment.startted && !comment.isSingleLined {
-			if ch == ASTERISK {
+		if comment.startted {
+			if ch == ASTERISK && !comment.isSingleLined {
 				comment.canEnd = true
 				continue
 			}
-			if comment.canEnd && ch == SLASH {
+			if comment.canEnd && ch == SLASH && !comment.isSingleLined {
 				comment.stop()
 				continue
 			}


### PR DESCRIPTION
While using the library I encountered an issue, where single line comment can be ended with `*/`.
Example:
```jsonc
{
  // I commented a glob pattern like this "**/*"
  "test" : "Hello"
}
```
The error I got was `invalid character '*' looking for beginning of value`.

I added a simple check to not try and end the comment with `*/` if the comment is single line.