### PR TITLE
Ignore quotes inside comments

### DIFF
--- a/jsonc_test.go
+++ b/jsonc_test.go
@@ -30,7 +30,7 @@ func init() {
 	jsoncTest = testsStruct{
 		validBlock:    b(`{"foo": /** this is a bloc/k comm\"ent */ "bar foo", "true": /* true */ false, "number": 42, "object": { "test": "done" }, "array" : [1, 2, 3], "url" : "https://github.com", "escape":"\"wo//rking" }`),
 		invalidBlock:  b(`{"foo": /* this is a block comment "bar foo", "true": false, "number": 42, "object": { "test": "done" }, "array" : [1, 2, 3], "url" : "https://github.com", "escape":"\"wo//rking }`),
-		validSingle:   b("{\"foo\": // this is a single line comm\\\"ent\n\"bar foo\", \"true\": false, \"number\": 42, \"object\": { \"test\": \"done\" }, \"array\" : [1, 2, 3], \"url\" : \"https://github.com\", \"escape\":\"\\\"wo//rking\" }"),
+		validSingle:   b("{\"foo\": // this is a \"single **/line comm\\\"ent\n\"bar foo\", \"true\": false, \"number\": 42, \"object\": { \"test\": \"done\" }, \"array\" : [1, 2, 3], \"url\" : \"https://github.com\", \"escape\":\"\\\"wo//rking\" }"),
 		invalidSingle: b(`{"foo": // this is a single line comment "bar foo", "true": false, "number": 42, "object": { "test": "done" }, "array" : [1, 2, 3], "url" : "https://github.com", "escape":"\"wo//rking" }`),
 		validHash:     b("{\"foo\": # this is a single line comm\\\"ent\n\"bar foo\", \"true\": false, \"number\": 42, \"object\": { \"test\": \"done\" }, \"array\" : [1, 2, 3], \"url\" : \"https://github.com\", \"escape\":\"\\\"wo//rking\" }"),
 		invalidHash:   b(`{"foo": # this is a single line comment "bar foo", "true": false, "number": 42, "object": { "test": "done" }, "array" : [1, 2, 3], "url" : "https://github.com", "escape":"\"wo//rking" }`),

--- a/translator.go
+++ b/translator.go
@@ -50,7 +50,7 @@ func translate(s []byte) []byte {
 			escaped = !escaped
 			continue
 		}
-		if ch == QUOTE {
+		if ch == QUOTE && !comment.startted {
 			quote = !quote
 		}
 		if (ch == SPACE || ch == TAB) && !quote {


### PR DESCRIPTION
Added a small fix, that will ignore quotes inside comments. Previously, this JSON would break:
```jsonc
{
  // This one quote "
  "makes": "everything else broken"
}
```

Additionally added to tests my previous fix, that was ending single line comments with `**/` and current issue with quotes.