### PR TITLE
remove deprecated io/ioutil

### DIFF
--- a/jsonc.go
+++ b/jsonc.go
@@ -24,7 +24,7 @@ package jsonc
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 )
 
 // ToJSON returns JSON equivalent of JSON with comments
@@ -34,7 +34,7 @@ func ToJSON(b []byte) []byte {
 
 // ReadFromFile reads jsonc file and returns JSONC and JSON encodings
 func ReadFromFile(filename string) ([]byte, []byte, error) {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/jsonc_test.go
+++ b/jsonc_test.go
@@ -2,7 +2,6 @@ package jsonc
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -115,7 +114,7 @@ func TestUnmarshal(t *testing.T) {
 }
 
 func TestReadFromFile(t *testing.T) {
-	tmp, err := ioutil.TempFile("", "ReadFromFileTest")
+	tmp, err := os.CreateTemp("", "ReadFromFileTest")
 	if err != nil {
 		t.Skip("Unable to create temp file.", err)
 	}


### PR DESCRIPTION
> Deprecated: As of Go 1.16, the same functionality is now provided by package [io](https://pkg.go.dev/io) or package [os](https://pkg.go.dev/os), and those implementations should be preferred in new code. See the specific function documentation for details.

https://pkg.go.dev/io/ioutil